### PR TITLE
Try fix password reset bug, allow email-only requests when username is blank

### DIFF
--- a/rkauth_flask.py
+++ b/rkauth_flask.py
@@ -467,18 +467,19 @@ def getpasswordresetlink():
         if not flask.request.is_json:
             return "/auth/getpasswordresetlink was expecting application/json", 500
 
-        if 'username' in flask.request.json:
+        if 'username' in flask.request.json and flask.request.json['username']:
             username = flask.request.json['username']
             them = get_user_by_username( username )
             if them is None:
                 return f"username {username} not known", 500
-        elif 'email' in flask.request.json:
+        elif 'email' in flask.request.json and flask.request.json['email']:
             email = flask.request.json['email']
             them = get_users_by_email( email )
             if them is None:
                 return f"email {email} not known", 500
         else:
             return "Must include either 'username' or 'email' in POST data", 500
+
 
         if not isinstance( them, list ):
             them = [ them ]


### PR DESCRIPTION
This change ensures that an empty "username": "" is ignored, allowing the handler to fall back to the email lookup.